### PR TITLE
add red/blue

### DIFF
--- a/twoeyes/interface.py
+++ b/twoeyes/interface.py
@@ -65,7 +65,15 @@ class MakeYourOwn(Stereo):
         padding = self.padding
 
         # set up the layout for the widgets
-        todo = VBox([Label('Output Types:'), self.widgets['do-redcyan'], self.widgets['do-gif']], layout=Layout(width=f'{3*width/4:.0f}px'))
+        todo = VBox(
+            [
+                Label('Output Types:'), 
+                self.widgets['do-redcyan'], 
+                self.widgets['do-redblue'], 
+                self.widgets['do-gif']
+            ], 
+            layout=Layout(width=f'{3*width/4:.0f}px')
+        )
         labeled_rotation = VBox([Label('Rotation:'), self.widgets['rotation']])
         options = HBox([labeled_rotation, todo], layout=Layout(width=f'{width}px', margin=f'0px {padding}px 0px {padding}px'))
 
@@ -154,6 +162,7 @@ class MakeYourOwn(Stereo):
 
         # create widgets for what kinds of stereographs to make
         self.widgets['do-redcyan'] = Checkbox(value=True, indent=False, description='red/cyan', layout=Layout(width='auto'))
+        self.widgets['do-redblue'] = Checkbox(value=False, indent=False, description='red/blue', Layout=Layout(width='auto'))
         self.widgets['do-gif'] = Checkbox(value=False, indent=False,  description='animated', layout=Layout(width='auto'))
         #self.widgets['do-sidebyside'] = Checkbox(value=False, description='sidebyside', layout=Layout(width='auto'))
 
@@ -322,7 +331,10 @@ class MakeYourOwn(Stereo):
             return
 
         if self.widgets['do-redcyan'].value:
-            filename = self.to_anaglyph()
+            filename = self.to_anaglyph(use_green=True)
+            self.display_stereograph(filename)
+        if self.widgets['do-redblue'].value:
+            filename = self.to_anaglyph(use_green=False)
             self.display_stereograph(filename)
         if self.widgets['do-gif'].value:
             filename = self.to_gif()

--- a/twoeyes/stereo.py
+++ b/twoeyes/stereo.py
@@ -131,13 +131,14 @@ class Stereo:
         self.write_output(f'Saved {label} stereograph to {filename}')
         return filename
 
-    def to_anaglyph(self, directory=''):
+    def to_anaglyph(self, directory='', use_green = True):
         '''
-        Output stereograph as a red-cyan image pair.
+        Output stereograph as a red and cyan (or blue if use_green is false) image pair.
         '''
 
-        # set the label
-        label = 'red-cyan'
+        # set the label red-blue. Unfortunately computer monitors do not emit 
+        # cyan wavelength light
+        label = 'red-cyan' if use_green else 'red-blue'
 
         # first convert images to black and white (width x height)
         left = np.array(self.rotate_image(self.images['left'].convert('L')))
@@ -145,9 +146,19 @@ class Stereo:
 
         # construct a combined image by populating the RGB channels
         merged = np.zeros_like(np.array(self.rotate_image(self.images['left'])))
-        merged[:,:,0] += left
-        merged[:,:,1] += right
-        merged[:,:,2] += right
+
+        # right perspective image should be red
+        merged[:,:,0] += left 
+
+        # we have the option to remove green because it is not filtered by 
+        # either cyan or red lenses, causing part of the right image to show up 
+        # through the left (red) filter
+        merged[:,:,1] = right if use_green else 0
+
+        # left perspective image should be blue
+        merged[:,:,2] = right
+
+        # combine into image
         combined = Image.fromarray(merged)
 
         # save to an image file


### PR DESCRIPTION
Hi Dr Berta-Thompson,

While Red/Cyan stereographs have a better color representation of the original image, I personally find it causes me much more eye strain then Red/Blue stereographs, so I went ahead and added a feature to this package that allows users to export Red/Blue stereographs as well as Red/Cyan stereographs. 

I believe this is because the computer monitors we use only a mix of blue/green for the cyan image, and for the red filter in the stereograph, it only filters out the blue, not the green. This leads to a double image and confuses my eyes, causing a noticeable amount of extra strain and difficulty in focussing. 

Anyway, I implemented a simple solution that just allows users of the notebook to choose which color scheme they want rather than being forced to use one or the other.

You can see the differences of the color schemes below, try looking at them with the glasses:

Red/Cyan  
![stereograph-by--red-cyan-000](https://github.com/user-attachments/assets/76e87a38-7b25-43d6-807a-f11bcfcf82c5)

Red/Blue  
![stereograph-by--red-blue-000](https://github.com/user-attachments/assets/384905f3-a5a2-4780-a8b9-6bab234c23b1)
